### PR TITLE
add hour method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,14 @@ impl Hours {
             Hours::Hour12am(h) => Hours::Hour24(h),
         }
     }
+
+    pub fn hour(&self) -> (u8, Option<bool>) {
+        match *self {
+            Hours::Hour24(h) => (h, None),
+            Hours::Hour12am(h) => (h, Some(false)),
+            Hours::Hour12pm(h) => (h, Some(true)),
+        }
+    }
 }
 
 impl From<u8> for Hours {


### PR DESCRIPTION
Hour24 or Hour12 are usually used in a project.

In Hour24 mode, ```h.hour().0``` this method is very convenient to get the hour

In Hour12 mode, ```h.hour().1.unwrap()``` it is easy to judge whether it is pm or am